### PR TITLE
Add CI badge to README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,12 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Run unit tests
+      - name: Run unit tests and generate coverage report
         run: |
           coverage run --source ./src -m pytest
           coverage report -m
           coverage xml -i -o coverage.xml
-      # NOTE: GitHub Actions and Code Climate do not seem to get along
-      # very well: https://github.com/codeclimate/test-reporter/issues/406
-      - name: Test & publish code coverage
+      - name: Publish code coverage report
         uses: paambaati/codeclimate-action@v2.7.5
         env:
           # FIXME: This ID should be abstracted into a secret and not hardcoded here

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,6 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      - name: Prepare Code Climate for coverage report
-        run: |
-          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-          chmod +x ./cc-test-reporter
-          GIT_BRANCH=$GITHUB_REF GIT_COMMIT_SHA=$GITHUB_SHA ./cc-test-reporter before-build
       - name: Run unit tests
         run: |
           coverage run --source ./src -m pytest
@@ -37,8 +32,8 @@ jobs:
           coverage xml -i -o coverage.xml
       # NOTE: GitHub Actions and Code Climate do not seem to get along
       # very well: https://github.com/codeclimate/test-reporter/issues/406
-      - name: Report coverage
-        run: GIT_BRANCH=$GITHUB_REF GIT_COMMIT_SHA=$GITHUB_SHA ./cc-test-reporter after-build -t coverage.py --exit-code $?
+      - name: Test & publish code coverage
+        uses: paambaati/codeclimate-action@v2.7.5
         env:
           # FIXME: This ID should be abstracted into a secret and not hardcoded here
           CC_TEST_REPORTER_ID: fbb02caaba945d0c6c7bf33428f6900c90af91a9a4b067aa506e4b39c812b4a5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Maintainability](https://api.codeclimate.com/v1/badges/0c81b87985e948b90544/maintainability)](https://codeclimate.com/github/promulo/pinga/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/0c81b87985e948b90544/test_coverage)](https://codeclimate.com/github/promulo/pinga/test_coverage)
+![CI](https://github.com/promulo/pinga/workflows/Pinga%20CI/badge.svg) [![Maintainability](https://api.codeclimate.com/v1/badges/0c81b87985e948b90544/maintainability)](https://codeclimate.com/github/promulo/pinga/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/0c81b87985e948b90544/test_coverage)](https://codeclimate.com/github/promulo/pinga/test_coverage)
 
 # Pinga - A simple website status checker
 


### PR DESCRIPTION
This PR adds the CI status badge to the README and also changes (again) the coverage report upload.