### PR TITLE
[GH-16] Add first version of Kafka producer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,7 @@ on:
     branches: [master]
 jobs:
   build:
-    # Running on macOS as a workaround to https://github.com/paambaati/codeclimate-action/issues/275
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python 3.8

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,9 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/focal64"
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 3096
+    v.cpus = 4
+  end
+  config.vm.network "private_network", ip: "192.168.50.50"
+  config.vm.synced_folder ".", "/vagrant", type: "nfs"
+end

--- a/pinga.cfg
+++ b/pinga.cfg
@@ -1,2 +1,8 @@
+[kafka]
+service_uri=
+ssl_cafile=
+ssl_certfile=
+ssl_keyfile=
+
 [checker]
 sites_list=sites.json

--- a/pinga/checker.py
+++ b/pinga/checker.py
@@ -4,6 +4,13 @@ from log import get_logger
 
 
 def check_site(site_url: str) -> dict:
+    """
+    Checks if a given site is up or now by sending and HTTP
+    request to the given URL
+
+    :param site_url: the event to be sent. It must UTF-8 encodable.
+    :returns: the result of the HTTP request as dict
+    """
     logger = get_logger()
     try:
         response = requests.get(site_url)

--- a/pinga/config.py
+++ b/pinga/config.py
@@ -10,16 +10,14 @@ from pinga.schema import SITES_SCHEMA
 
 def get_kafka_config() -> dict:
     config = _load_cfg_file()
-
     try:
         return dict(config["kafka"])
-    except NoSectionError as err:
-        raise BadConfigException(str(err))
+    except KeyError:
+        raise BadConfigException("Required section 'kafka' not found in .cfg file")
 
 
 def get_sites_list() -> dict:
     config = _load_cfg_file()
-
     try:
         sites_list = config.get('checker', 'sites_list')
     except (NoSectionError, NoOptionError) as err:

--- a/pinga/config.py
+++ b/pinga/config.py
@@ -8,6 +8,15 @@ from jsonschema import SchemaError, ValidationError, validate
 from pinga.schema import SITES_SCHEMA
 
 
+def get_kafka_config() -> dict:
+    config = _load_cfg_file()
+
+    try:
+        return dict(config["kafka"])
+    except NoSectionError as err:
+        raise BadConfigException(str(err))
+
+
 def get_sites_list() -> dict:
     config = _load_cfg_file()
 

--- a/pinga/events/producer.py
+++ b/pinga/events/producer.py
@@ -1,0 +1,44 @@
+from kafka import KafkaProducer
+from pinga.config import get_kafka_config
+from pinga.log import get_logger
+
+
+class Producer():
+    """
+    A Producer object abstracts the handling
+    of sending Kafka events to a given cluster
+    """
+    def __init__(self):
+        self._logger = get_logger()
+
+        kafka_config = get_kafka_config()
+        self._kafka_producer = KafkaProducer(
+            bootstrap_servers=kafka_config["service_uri"],
+            security_protocol="SSL",
+            ssl_cafile=kafka_config["ssl_cafile"],
+            ssl_certfile=kafka_config["ssl_certfile"],
+            ssl_keyfile=kafka_config["ssl_keyfile"],
+        )
+
+    def emit(self, event):
+        """
+        emit sends a given event to the Kafka cluster
+
+        :param event: the event to be sent. It must UTF-8 encodable.
+        :raises ProducerException: event provided is invalid
+        """
+        try:
+            message = event.encode("utf-8")
+        except AttributeError:
+            raise ProducerException(f"emit: event parameter {event} is invalid")
+
+        if event:
+            self._logger.info("Emitting event: {}".format(event))
+            self._kafka_producer.send("pinga-events", message)
+            self._kafka_producer.flush()
+        else:
+            self._logger.warning("Ignoring attempt of emitting empty string event")
+
+
+class ProducerException(Exception):
+    pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jsonschema==3.2.0
+kafka-python==2.0.2
 requests==2.25.1

--- a/tests/config/bad.cfg
+++ b/tests/config/bad.cfg
@@ -1,0 +1,2 @@
+[foo]
+bar = xpto

--- a/tests/config/pinga-test.cfg
+++ b/tests/config/pinga-test.cfg
@@ -1,2 +1,8 @@
+[kafka]
+service_uri=example.org:123456
+ssl_cafile=ca.pem
+ssl_certfile=service.cert
+ssl_keyfile=service.key
+
 [checker]
 sites_list=tests/config/sites-test.json

--- a/tests/config/pinga-test.cfg
+++ b/tests/config/pinga-test.cfg
@@ -1,8 +1,8 @@
 [kafka]
-service_uri=example.org:123456
-ssl_cafile=ca.pem
-ssl_certfile=service.cert
-ssl_keyfile=service.key
+service_uri = example.org:123456
+ssl_cafile = ca.pem
+ssl_certfile = service.cert
+ssl_keyfile = service.key
 
 [checker]
-sites_list=tests/config/sites-test.json
+sites_list = tests/config/sites-test.json

--- a/tests/events/test_producer.py
+++ b/tests/events/test_producer.py
@@ -1,0 +1,43 @@
+from unittest.mock import patch
+
+import pytest
+from pinga.events.producer import Producer, ProducerException
+
+
+@patch("pinga.events.producer.KafkaProducer")
+def test_producer_emit_happy_path(mock_kafka):
+    event = "hello world"
+
+    producer = Producer()
+    producer.emit(event)
+
+    mock_kafka().send.assert_called_with("pinga-events", event.encode("utf-8"))
+    mock_kafka().flush.assert_called_once()
+
+
+@patch("pinga.events.producer.KafkaProducer")
+def test_producer_emit_empty_event_ignored(mock_kafka):
+    event = ""
+
+    producer = Producer()
+    producer.emit(event)
+
+    mock_kafka().send.assert_not_called()
+    mock_kafka().flush.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "event", [
+        (-1,),
+        (lambda x: x)
+        (None)
+    ]
+)
+@patch("pinga.events.producer.KafkaProducer")
+def test_producer_emit_invalid_event(mock_kafka, event):
+    producer = Producer()
+
+    with pytest.raises(ProducerException) as exc_info:
+        producer.emit(event)
+
+    assert str(exc_info.value) == f"emit: event parameter {event} is invalid"

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,7 +1,7 @@
 import pytest
 from jsonschema import SchemaError, ValidationError, validate
 from pinga.checker import check_site
-from schema import STATUS_SCHEMA
+from pinga.schema import STATUS_SCHEMA
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from pinga.config import BadConfigException, get_sites_list
+from pinga.config import BadConfigException, get_kafka_config, get_sites_list
 
 
 @pytest.mark.parametrize(
@@ -26,6 +26,16 @@ def test_get_sites_list_errors(mock_parser, sites_file, error_msg):
 
 def test_get_sites_list_happy_path():
     sites_list = get_sites_list()
+
     assert sites_list is not None
     assert "sites" in sites_list
     assert "http://test.example.org" in sites_list["sites"]
+
+
+def test_get_kafka_config():
+    kafka_config = get_kafka_config()
+
+    assert kafka_config["service_uri"] == "example.org:123456"
+    assert kafka_config["ssl_cafile"] == "ca.pem"
+    assert kafka_config["ssl_certfile"] == "service.cert"
+    assert kafka_config["ssl_keyfile"] == "service.key"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,6 +24,15 @@ def test_get_sites_list_errors(mock_parser, sites_file, error_msg):
     assert str(exc.value) == error_msg
 
 
+def test_get_sites_list_missing(monkeypatch):
+    monkeypatch.setenv("PINGA_CFG", "tests/config/bad.cfg")
+
+    with pytest.raises(BadConfigException) as exc:
+        get_sites_list()
+
+    assert str(exc.value) == "No section: 'checker'"
+
+
 def test_get_sites_list_happy_path():
     sites_list = get_sites_list()
 
@@ -32,10 +41,19 @@ def test_get_sites_list_happy_path():
     assert "http://test.example.org" in sites_list["sites"]
 
 
-def test_get_kafka_config():
+def test_get_kafka_config_happy_path():
     kafka_config = get_kafka_config()
 
     assert kafka_config["service_uri"] == "example.org:123456"
     assert kafka_config["ssl_cafile"] == "ca.pem"
     assert kafka_config["ssl_certfile"] == "service.cert"
     assert kafka_config["ssl_keyfile"] == "service.key"
+
+
+def test_get_kafka_config_missing(monkeypatch):
+    monkeypatch.setenv("PINGA_CFG", "tests/config/bad.cfg")
+
+    with pytest.raises(BadConfigException) as exc:
+        get_kafka_config()
+
+    assert str(exc.value) == "Required section 'kafka' not found in .cfg file"


### PR DESCRIPTION
This PR adds the first version of the Kafka event producer to be used to broadcast `pinga` events.

Closes #16 