### PR TITLE
[GH-27] Add systemd files and pinga.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,4 +149,7 @@ dmypy.json
 !.vscode/extensions.json
 *.code-workspace
 
+### vagrant ###
+.vagrant
+
 # End of https://www.toptal.com/developers/gitignore/api/vscode,python

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,8 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/focal64"
   config.vm.provider "virtualbox" do |v|
-    v.memory = 3096
-    v.cpus = 4
+    v.memory = 2048
+    v.cpus = 2
   end
   config.vm.network "private_network", ip: "192.168.50.50"
   config.vm.synced_folder ".", "/vagrant", type: "nfs"

--- a/pinga.sh
+++ b/pinga.sh
@@ -3,7 +3,7 @@
 install_dependencies() {
     python3 -m venv .venv
     source .venv/bin/activate
-    pip3 install -r /opt/pinga/requirements.txt
+    pip3 install -r requirements.txt
 }
 
 cd /opt/pinga
@@ -13,10 +13,10 @@ if [ $# -lt 1 ]; then
     exit 1
 elif [ $1 == "producer" ]; then
     install_dependencies
-    .venv/bin/python /opt/pinga/run_producer.py
+    .venv/bin/python run_producer.py
 elif [ $1 == "consumer" ]; then
     install_dependencies
-    .venv/bin/python /opt/pinga/run_consumer.py
+    .venv/bin/python run_consumer.py
 else
     echo "FATAL: Unknown option ${1}. Valid options are: producer|consumer"
 fi

--- a/pinga.sh
+++ b/pinga.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+install_dependencies() {
+    python3 -m venv .venv
+    source .venv/bin/activate
+    pip3 install -r /opt/pinga/requirements.txt
+}
+
+cd /opt/pinga
+
+if [ $# -lt 1 ]; then
+    echo "FATAL: No parameter supplied. Usage: ./pinga.sh producer|consumer"
+    exit 1
+elif [ $1 == "producer" ]; then
+    install_dependencies
+    .venv/bin/python /opt/pinga/run_producer.py
+elif [ $1 == "consumer" ]; then
+    install_dependencies
+    .venv/bin/python /opt/pinga/run_consumer.py
+else
+    echo "FATAL: Unknown option ${1}. Valid options are: producer|consumer"
+fi

--- a/systemd/pinga-consumer.service
+++ b/systemd/pinga-consumer.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Pinga website checker consumer service
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=2
+ExecStart=/opt/pinga/pinga.sh consumer
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/pinga-producer.service
+++ b/systemd/pinga-producer.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Pinga website checker producer service
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=2
+ExecStart=/opt/pinga/pinga.sh producer
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds the systemd service files for both Pinga producer and consumer to be able to run as system services.

Closes #27 