### PR TITLE
[GH-31] Create database table upon consumer execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ executed in any given order.
 
 ## Setup of aiven services and Pinga configuration
 
-At this stage of development, Pinga relies on two DBaaS products: **aiven for Apache Kafka** and
-**aiven for PostgreSQL**. It is assumed that those services are provisioned and running.
-Please refer to [aiven](https://help.aiven.io/en/articles/489573-getting-started-with-aiven-postgresql)
+At this stage of development, Pinga relies on two DBaaS products: [**aiven for Apache Kafka**](https://aiven.io/kafka) and [**aiven for PostgreSQL**](https://aiven.io/postgresql). It is assumed that those services are provisioned and running. Please refer to [aiven](https://help.aiven.io/en/articles/489573-getting-started-with-aiven-postgresql)
 [documentation](https://help.aiven.io/en/articles/489572-getting-started-with-aiven-kafka) for
 details about setting up those services.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,27 @@ executed in any given order.
 
 ## Setup of aiven services and Pinga configuration
 
-TBD
+At this stage of development, Pinga relies on two DBaaS products: **aiven for Apache Kafka** and
+**aiven for PostgreSQL**. It is assumed that those services are provisioned and running.
+Please refer to [aiven](https://help.aiven.io/en/articles/489573-getting-started-with-aiven-postgresql)
+[documentation](https://help.aiven.io/en/articles/489572-getting-started-with-aiven-kafka) for
+details about setting up those services.
+
+Pinga configuration is set in the `pinga.cfg` file. It consists of three sections, `kafka`,
+`postgres` and `checker`.
+
+### kafka
+This section specifies the aiven Kafka cluster that Pinga will connect to. Please replace the
+placeholders for `service_uri`, `ssl_cafile`, `ssl_certfile` and `ssl_keyfile` with the appropriate
+values. They can be easily retrieved from the aiven console.
+
+### postgres
+This section defines the PostgreSQL instance where events will be saved. Please fill the
+`service_uri` with the value provided by the aiven console.
+
+### checker
+This section specifies a JSON file containing a list of websites to be checked by Pinga. An example
+is provided and named `sites.json`.
 
 ## Running Pinga components using docker-compose
 
@@ -33,6 +53,8 @@ The easiest way to see Pinga working is by running the provided `docker-compose`
 $ docker-compose up
 ```
 The command above will run both Pinga Producer and Pinga Consumer in separate containers.
+
+In case of code changes, `docker-compose build` must be executed before restarting.
 
 ## Running Pinga components separately as standalone processes
 
@@ -79,9 +101,12 @@ Tests and Code Climate checks are done for every PR. [GitHub Actions](https://gi
 * [Kanban board](https://github.com/promulo/pinga/projects/1)
 * [Open issues](https://github.com/promulo/pinga/issues)
 
-## References
+## Further documentation and references
 
+* https://help.aiven.io/en/articles/489573-getting-started-with-aiven-postgresql
 * https://help.aiven.io/en/articles/489572-getting-started-with-aiven-kafka
 * https://kafka-python.readthedocs.io/en/master/index.html
 * http://www.gevent.org/
+* https://www.psycopg.org/
+* https://requests.readthedocs.io/en/master/
 * https://registry.terraform.io/providers/aiven/aiven/latest/docs

--- a/pinga/events/consumer.py
+++ b/pinga/events/consumer.py
@@ -5,7 +5,7 @@ from jsonschema import SchemaError, ValidationError, validate
 from kafka import KafkaConsumer
 from pinga.config import get_kafka_config
 from pinga.log import get_logger
-from pinga.persistence import get_db_conn, save_event
+from pinga.persistence import create_events_table, get_db_conn, save_event
 from pinga.schema import STATUS_SCHEMA
 
 
@@ -30,6 +30,7 @@ class Consumer:
             ssl_keyfile=kafka_config["ssl_keyfile"],
         )
         self._db_conn = get_db_conn()
+        create_events_table(self._db_conn)
 
     def consume(self):
         """

--- a/tests/events/test_consumer.py
+++ b/tests/events/test_consumer.py
@@ -51,3 +51,12 @@ def test_consumer_consume_happy_path(mock_kafka, mock_save, mock_db_conn):
     consumer.consume()
 
     mock_save.assert_has_calls([call(ANY, event_1), call(ANY, event_2)])
+
+
+@patch("pinga.events.consumer.get_db_conn")
+@patch("pinga.events.consumer.create_events_table")
+@patch("pinga.events.consumer.KafkaConsumer")
+def test_consumer_table_created(mock_kafka, mock_create_table, mock_db_conn):
+    _ = Consumer()
+
+    mock_create_table.assert_called_once_with(mock_db_conn())


### PR DESCRIPTION
This PR adds database creation to the consumer object initial setup.

Closes #31 